### PR TITLE
Update UI for topmost post

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -104,7 +104,6 @@ export default function Layout({ location, title, children }: Props) {
   // Hook for updating currentY state
   // This gets passed to NavBar's `pageYOffset` props
   const [currentY: number, setCurrentY: () => any] = useState(0)
-
   // Hook for scrollPercent of the document
   // between 0...1
   const [scrollPercent: number, setScrollPercent: () => any] = useState(0)
@@ -196,13 +195,13 @@ export default function Layout({ location, title, children }: Props) {
   //   // },
   // })
 
-  const [d, setD] = useState({ x: 100, y: 100 })
+  const [d, setD] = useState({ x: -75, y: -75 })
   const [drag, toggleDrag] = useState(false)
 
   const { dX, dY } = useSpring({
-    from: { dX: 100, dY: 100 },
-    dX: typeof window !== "undefined" ? d.x : 100,
-    dY: typeof window !== "undefined" ? d.y : 100,
+    from: { dX: -100, dY: -100 },
+    dX: typeof window !== "undefined" ? d.x : -75,
+    dY: typeof window !== "undefined" ? d.y : -75,
     config: { mass: 1, tension: 250, friction: 10 },
   })
 
@@ -248,7 +247,7 @@ export default function Layout({ location, title, children }: Props) {
         `}</style>
       </AnimatedPaper>
 
-      <NavBar
+      {/* <NavBar
         location={location}
         // TODO: refactor logic to cap opacity at 1
         opacity={
@@ -258,7 +257,7 @@ export default function Layout({ location, title, children }: Props) {
               : currentY / (window.innerHeight / 2)
             : 0
         }
-      />
+      /> */}
       <div
         style={{ overflowX: "hidden" }}
         // add listener for when mouse moves too fast and leaves the `.draggable-glass`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link, graphql } from "gatsby"
 import Image from "gatsby-image"
 import { CommentCount } from "disqus-react"
-import { Grid } from "@material-ui/core"
+import { Grid, Card, Divider } from "@material-ui/core"
 
 import Bio from "../components/bio"
 import Layout from "../components/layout"
@@ -60,6 +60,7 @@ function Post({
   id,
   image,
   index,
+  innerWidth,
 }: Props) {
   //_.map + _.kebabCase each tag in frontmatter.tags
   let kebabTags = map(tags, tag => kebabCase(tag))
@@ -71,24 +72,8 @@ function Post({
     title: title,
   }
 
-  return (
-    <Grid
-      item
-      lg={index === 0 ? 12 : 3}
-      md={index === 0 ? 12 : 4}
-      sm={index === 0 ? 12 : 6}
-      xs={12}
-    >
-      <Link style={{ boxShadow: `none` }} to={linkTo}>
-        {image && (
-          <Image
-            fluid={image.childImageSharp.fluid}
-            alt={linkTo}
-            style={{}}
-            imgStyle={{}}
-          />
-        )}
-      </Link>
+  const PostDetails = (
+    <>
       <h3
         style={{
           marginTop: rhythm(1 / 2),
@@ -118,11 +103,71 @@ function Post({
           </CommentCount>
         </small>
       </code>
+    </>
+  )
+
+  const PostDetailsTop = (
+    <div
+      className={"post-details__card"}
+      style={{
+        background: innerWidth >= 600 ? "white" : `none`,
+        paddingTop: rhythm(1 / 2),
+        paddingBottom: rhythm(1),
+        paddingLeft: rhythm(1),
+        maxWidth: rhythm(18),
+        transform:
+          innerWidth >= 600 ? `translate(${rhythm(1)}, -${rhythm(2)})` : `none`,
+      }}
+    >
+      {PostDetails}
+      <style jsx>{`
+        .post-details__card {
+          transition: box-shadow 100ms ease-in-out, transform 322ms ease-in-out,
+            background 322ms ease-in-out;
+        }
+      `}</style>
+    </div>
+  )
+
+  return (
+    <Grid
+      item
+      lg={index === 0 ? 12 : 3}
+      md={index === 0 ? 12 : 4}
+      sm={index === 0 ? 12 : 6}
+      xs={12}
+    >
+      <Link style={{ boxShadow: `none` }} to={linkTo}>
+        {image && (
+          <Image
+            fluid={image.childImageSharp.fluid}
+            alt={linkTo}
+            style={{}}
+            imgStyle={{}}
+          />
+        )}
+      </Link>
+      {index === 0 ? PostDetailsTop : PostDetails}
+      {index === 0 && <Divider />}
     </Grid>
   )
 }
 
 class BlogIndex extends React.Component {
+  state = {
+    innerWidth: 0,
+  }
+  handleResize = () => {
+    this.setState({
+      innerWidth: window.innerWidth,
+    })
+  }
+  componentDidMount() {
+    this.setState({
+      innerWidth: window.innerWidth,
+    })
+    window.addEventListener("resize", this.handleResize)
+  }
   render() {
     const { data } = this.props
     const siteTitle = data.site.siteMetadata.title
@@ -148,6 +193,7 @@ class BlogIndex extends React.Component {
                 id={node.id}
                 image={node.frontmatter.image}
                 index={index}
+                innerWidth={this.state.innerWidth}
               />
             )
           })}


### PR DESCRIPTION
# Description

Updated the UI for the topmost post to mimic https://airbnb.design/.

Added window `resize` event listener to transition the top most post back and forth bewteen `"top"` and `"regular"`, when crossing over the `600px` width breakpoint

- Removed NavBar