### PR TITLE
extract <Discussion/> & <DocumentToReactComponents/>

### DIFF
--- a/src/components/TemplateComponents/Contentful/index.tsx
+++ b/src/components/TemplateComponents/Contentful/index.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import { BLOCKS } from "@contentful/rich-text-types"
+
+interface Props {
+  document: {
+    nodeType: BLOCKS.DOCUMENT
+    content: Array<any>
+    data: any
+  }
+}
+
+export default function DocumentToReactComponents({ document }: Props) {
+  /**
+   * Arguments to pass to: documentToReactComponents(document, options)
+   * https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer
+   **/
+  const options = {
+    renderNode: {
+      [BLOCKS.EMBEDDED_ASSET]: node => {
+        // console.log(node)
+        let { file, title, description } = node.data.target.fields
+        // console.log(file["en-US"].url)
+        return <img src={file["en-US"].url} alt={description["en-US"]} />
+      },
+    },
+  }
+  // console.log(documentToReactComponents(document, options))
+
+  return documentToReactComponents(document, options)
+}

--- a/src/components/TemplateComponents/Discussion/index.tsx
+++ b/src/components/TemplateComponents/Discussion/index.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { DiscussionEmbed } from "disqus-react"
+
+interface Props {
+  locationPathname: string // `/first-climbing-trips-of-2019/`
+  identifier: string // `9098d5ea-e984-5c0b-a1cf-b514577eb29f`
+  title: string // `First Climbing Trips of 2019`
+}
+
+export default function Discussion({
+  locationPathname,
+  identifier,
+  title,
+}: Props) {
+  const disqusShortname = "coffeecodeclimb"
+  const disqusConfig = {
+    url: "https://coffeecodeclimb.com" + locationPathname,
+    identifier: identifier,
+    title: title,
+  }
+
+  return (
+    <>
+      <h2>Discussion</h2>
+      <DiscussionEmbed shortname={disqusShortname} config={disqusConfig} />
+    </>
+  )
+}

--- a/src/components/TemplateComponents/index.tsx
+++ b/src/components/TemplateComponents/index.tsx
@@ -1,1 +1,2 @@
 export { default as Discussion } from "./Discussion"
+export { default as DocumentToReactComponents } from "./Contentful"

--- a/src/components/TemplateComponents/index.tsx
+++ b/src/components/TemplateComponents/index.tsx
@@ -1,0 +1,1 @@
+export { default as Discussion } from "./Discussion"

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { Link, graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
 
@@ -6,22 +6,15 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm, scale } from "@src/utils/typography"
-import { DiscussionEmbed } from "disqus-react"
+import { Discussion } from "@src/components/TemplateComponents"
 
-export default function BlogPostTemplate(props) {
-  const post = props.data.markdownRemark
-  const siteTitle = props.data.site.siteMetadata.title
-  const { previous, next } = props.pageContext
-
-  const disqusShortname = "coffeecodeclimb"
-  const disqusConfig = {
-    url: "https://coffeecodeclimb.com" + props.location.pathname,
-    identifier: post.id,
-    title: post.frontmatter.title,
-  }
+export default function BlogPostTemplate({ data, pageContext, location }) {
+  const post = data.markdownRemark
+  const { title: siteTitle } = data.site.siteMetadata
+  const { previous, next } = pageContext
 
   return (
-    <Layout location={props.location} title={siteTitle}>
+    <Layout location={location} title={siteTitle}>
       <SEO
         title={post.frontmatter.title}
         description={post.frontmatter.description || post.excerpt}
@@ -108,10 +101,11 @@ export default function BlogPostTemplate(props) {
         </li>
       </ul>
 
-      <h2>Discussion</h2>
-      <div className="disqus">
-        <DiscussionEmbed shortname={disqusShortname} config={disqusConfig} />
-      </div>
+      <Discussion
+        locationPathname={location.pathname}
+        identifier={post.id}
+        title={post.frontmatter.title}
+      />
     </Layout>
   )
 }

--- a/src/templates/contentful-blog-post.tsx
+++ b/src/templates/contentful-blog-post.tsx
@@ -6,7 +6,10 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm, scale } from "@src/utils/typography"
-import { Discussion } from "@src/components/TemplateComponents"
+import {
+  Discussion,
+  DocumentToReactComponents,
+} from "@src/components/TemplateComponents"
 
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { BLOCKS } from "@contentful/rich-text-types"
@@ -19,24 +22,7 @@ export default function ContentfulBlogPostTemplate({
   const post = data.contentfulBlogPost
   const { title: siteTitle } = data.site.siteMetadata
   const { previous, next } = pageContext
-
-  /**
-   * Arguments to pass to: documentToReactComponents(document, options)
-   * https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer
-   **/
-  const document: JSON = post.body.json
-  const options = {
-    renderNode: {
-      [BLOCKS.EMBEDDED_ASSET]: node => {
-        // console.log(node)
-        let { file, title, description } = node.data.target.fields
-        // console.log(file["en-US"].url)
-        return <img src={file["en-US"].url} alt={description["en-US"]} />
-      },
-    },
-  }
-  // console.log(documentToReactComponents(document, options))
-
+  console.log(post.body.json)
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title={post.title} description={post.description} />
@@ -54,13 +40,9 @@ export default function ContentfulBlogPostTemplate({
       </p>
 
       {/**
-       * NOTE: replace this div with documentToReactComponents()
-       * It converts Contenful's "rich text" (post.body.json)
-       * to react components.
-       *
        * <div dangerouslySetInnerHTML={{ __html: post.html }} />
        **/}
-      {documentToReactComponents(document, options)}
+      <DocumentToReactComponents document={post.body.json} />
 
       <small>
         Tags:{" "}

--- a/src/templates/contentful-blog-post.tsx
+++ b/src/templates/contentful-blog-post.tsx
@@ -1,20 +1,24 @@
-import React from "react"
+import * as React from "react"
 import { Link, graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
-import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import { BLOCKS } from "@contentful/rich-text-types"
-import Image from "gatsby-image"
 
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm, scale } from "@src/utils/typography"
-import { DiscussionEmbed } from "disqus-react"
+import { Discussion } from "@src/components/TemplateComponents"
 
-export default function ContentfulBlogPostTemplate(props) {
-  const post = props.data.contentfulBlogPost
-  const siteTitle = props.data.site.siteMetadata.title
-  const { previous, next } = props.pageContext
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import { BLOCKS } from "@contentful/rich-text-types"
+
+export default function ContentfulBlogPostTemplate({
+  data,
+  pageContext,
+  location,
+}) {
+  const post = data.contentfulBlogPost
+  const { title: siteTitle } = data.site.siteMetadata
+  const { previous, next } = pageContext
 
   /**
    * Arguments to pass to: documentToReactComponents(document, options)
@@ -33,15 +37,8 @@ export default function ContentfulBlogPostTemplate(props) {
   }
   // console.log(documentToReactComponents(document, options))
 
-  const disqusShortname = "coffeecodeclimb"
-  const disqusConfig = {
-    url: "https://coffeecodeclimb.com" + props.location.pathname,
-    identifier: post.id,
-    title: post.title,
-  }
-
   return (
-    <Layout location={props.location} title={siteTitle}>
+    <Layout location={location} title={siteTitle}>
       <SEO title={post.title} description={post.description} />
       <h1>{post.title}</h1>
 
@@ -133,10 +130,11 @@ export default function ContentfulBlogPostTemplate(props) {
         </li>
       </ul>
 
-      <h2>Discussion</h2>
-      <div className="disqus">
-        <DiscussionEmbed shortname={disqusShortname} config={disqusConfig} />
-      </div>
+      <Discussion
+        locationPathname={location.pathname}
+        identifier={post.id}
+        title={post.title}
+      />
     </Layout>
   )
 }


### PR DESCRIPTION
# Description

Prior to this, CodeClimate was returning a `C` rating. This changes attempt to fix some warnings for **cognitive complexity** and **maintainability**

extract two components to reduce the code-size of `blog-post` and `contentful-blog-post` templates
- `<Discussion/>`
- `<DocumentToReactComponents/>`