### PR TITLE
Exclude `/` from adsense plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -99,6 +99,7 @@ module.exports = {
       resolve: `gatsby-plugin-google-adsense`,
       options: {
         publisherId: `${process.env.GATSBY_GOOGLE_AD_CLIENT}`,
+        excludePaths: `/`,
       },
     },
     `gatsby-plugin-feed`,


### PR DESCRIPTION
# Description

add `excludePaths: `/`, to gatsby-plugin-google-adsense`
- there's no documentation for this so I'm just seeing if this works