### PR TITLE
sort combined markdown & contentful posts by date

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,6 +29,7 @@ exports.createPages = ({ graphql, actions }) => {
               frontmatter {
                 title
                 tags
+                date
               }
             }
           }
@@ -45,6 +46,7 @@ exports.createPages = ({ graphql, actions }) => {
               slug
               title
               tags
+              date
             }
           }
         }
@@ -58,7 +60,22 @@ exports.createPages = ({ graphql, actions }) => {
     // Create blog posts pages.
     const markdownPosts = result.data.allMarkdownRemark.edges
     const contentfulPosts = result.data.allContentfulBlogPost.edges
-    const posts = _.union(contentfulPosts, markdownPosts)
+
+    /**
+     * Combine Markdown & Contentful posts. Sort by newest Date.
+     */
+    const posts = _.sortBy(
+      _.union(contentfulPosts, markdownPosts),
+      ({ node }) => {
+        let date = new Date(
+          node.internal.type === `MarkdownRemark`
+            ? node.frontmatter.date
+            : node.date
+        )
+
+        return -date
+      }
+    )
 
     posts.forEach((post, index) => {
       const previous = index === posts.length - 1 ? null : posts[index + 1].node

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { rhythm } from "@src/utils/typography"
 
 // Tools
 import union from "lodash/union"
+import sortBy from "lodash/sortBy"
 import includes from "lodash/includes"
 import kebabCase from "lodash/kebabCase"
 import map from "lodash/map"
@@ -215,10 +216,21 @@ class BlogIndex extends React.Component {
   render() {
     const { data } = this.props
     const siteTitle = data.site.siteMetadata.title
+
     const markdownPosts = data.allMarkdownRemark.edges
     const contentfulPosts = data.allContentfulBlogPost.edges
 
-    const posts = union(contentfulPosts, markdownPosts)
+    /**
+     * Combine Markdown & Contentful posts. Sort by newest Date.
+     */
+    const posts = sortBy(union(contentfulPosts, markdownPosts), ({ node }) => {
+      let date = new Date(
+        node.internal.type === `MarkdownRemark`
+          ? node.frontmatter.date
+          : node.date
+      )
+      return -date
+    })
 
     return (
       <Layout location={this.props.location} title={siteTitle}>

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import union from "lodash/union"
+import sortBy from "lodash/sortBy"
 
 // Components
 import { Link, graphql } from "gatsby"
@@ -23,7 +24,22 @@ const Tags = ({ pageContext, data, location }) => {
   } = data.allContentfulBlogPost
 
   let totalCount: number = markdownRemarkTotalCount + contentfulTotalCount
-  let edges = union(contentfulEdges, markdownRemarkEdges)
+
+  /**
+   * Combine Markdown & Contentful posts. Sort by newest Date.
+   */
+  let edges = sortBy(
+    union(contentfulEdges, markdownRemarkEdges),
+    ({ node }) => {
+      let date = new Date(
+        node.internal.type === `MarkdownRemark`
+          ? node.frontmatter.date
+          : node.date
+      )
+
+      return -date
+    }
+  )
 
   const tagHeader = `${totalCount} post${
     totalCount === 1 ? "" : "s"
@@ -115,6 +131,7 @@ export const pageQuery = graphql`
           }
           frontmatter {
             title
+            date
           }
         }
       }
@@ -132,6 +149,7 @@ export const pageQuery = graphql`
           }
           slug
           title
+          date
         }
       }
     }


### PR DESCRIPTION
# Description

There was an issue with chronologically newer Markdown posts being displayer _after_ older Contentful posts. This was due to how the two groups were being combined (`_.union`).

I used `_.sortBy()` to sort the union by the `date` of each post, from newest to oldest.

- add `date` field to graphql queries 
- use `_.sortBy()`