### PR TITLE
Section header and toc styles

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -36,8 +36,20 @@ const Container = styled(animated.div)`
     top: 0 !important;
   }
 
+  ul {
+    margin-top: 0;
+  }
   li {
     list-style: none;
+    margin-bottom: 0;
+
+    /* Truncate and prevent line break */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  p {
+    margin-bottom: 0;
   }
 `
 

--- a/src/utils/typography/index.tsx
+++ b/src/utils/typography/index.tsx
@@ -9,7 +9,8 @@ Wordpress2016.bodyFontFamily = ["Cereal"]
 // const __geist_cyan = "#79ffe1"
 // const __geist_purple = "#f81ce5"
 
-Wordpress2016.overrideThemeStyles = () => {
+Wordpress2016.overrideThemeStyles = (a, b) => {
+  // console.log("a", a, "b", b)
   return {
     "a.gatsby-resp-image-link": {
       boxShadow: `none`,
@@ -39,6 +40,11 @@ Wordpress2016.overrideThemeStyles = () => {
     "h1, h2, h3, h4, h5, h6, p, label, span, li, td, th, summary": {
       color: "var(--text)",
     },
+    "h1 > code, h2 > code, h3 > code, h4 > code, h5 > code, h6 > code": {
+      // This allows `<code>` tags to inherit header font-sizes
+      fontSize: "unset",
+    },
+    code: {},
     "th, td": {
       borderBottomColor: "var(--table-border)",
     },


### PR DESCRIPTION
### Changes

Unset font-size for markdown <code>\`code\`</code> (aka `<code>` tags) in `# headers` (aka `<h1>`, `<h2>`, etc)
- this allows the generated `<code>` tags to inherit header font-size

Remove extra `margin` in the TOC `li`, `p`, `ul` elements
- this is visually more _compact_

#### Preview
![image](https://user-images.githubusercontent.com/26389321/85136793-28ae0180-b20e-11ea-90eb-8a151fe3e841.png)
