### PR TITLE
Consume new claps-query API

### DIFF
--- a/src/hooks/useOptimisticClaps.ts
+++ b/src/hooks/useOptimisticClaps.ts
@@ -2,11 +2,29 @@ import { useCallback, useState, useEffect } from "react"
 import axios from "axios"
 import _ from "lodash"
 
-export const useOptimisticClaps = (uri: string) => {
+interface Options {
+  /**
+   * The remaining number of claps a viewer can commit.
+   * - defaults to 60.
+   */
+  remainingClaps?: number
+}
+
+/**
+ * This is a custom hook to handle debouncing API calls to API Gateway.
+ * It will queue up claps, then merge them upon success.
+ *
+ * It also returns state for when a viewer has reached their clap limit.
+ */
+export const useOptimisticClaps = (
+  uri: string,
+  { remainingClaps = 60 }: Options
+) => {
   const [queuedClaps, setQueuedClaps] = useState(0)
   const [mergedClaps, setMergedClaps] = useState(0)
 
   const [clapLimitReached, setClapLimitReached] = useState(false)
+
   const updateClaps = useCallback(
     _.debounce(async (claps: number) => {
       if (clapLimitReached) return
@@ -18,11 +36,12 @@ export const useOptimisticClaps = (uri: string) => {
             slug: location.pathname,
           })
         )
-        // console.log("RESPONSE", res)
-        // console.log("PARSED", JSON.parse(res.data))
+
+        // TODO, instead of merging local state, merge the response instead
         setMergedClaps((m) => m + claps)
         setQueuedClaps(0)
       } catch (err) {
+        setQueuedClaps(0)
         // Object.getOwnPropertyNames(err)
         // ["stack", "message", "config", "request", "response", "isAxiosError", "toJSON"]
         // console.log("ERROR", err.response?.status)
@@ -31,11 +50,17 @@ export const useOptimisticClaps = (uri: string) => {
         }
       }
     }, 500),
-    [clapLimitReached, setClapLimitReached]
+    [clapLimitReached, setClapLimitReached, setQueuedClaps, setMergedClaps]
   )
-  const incrementClaps = () => {
+  const incrementClaps = (cb: () => void) => {
+    if (queuedClaps + mergedClaps >= remainingClaps) {
+      setClapLimitReached(true)
+      return
+    }
+
     if (!clapLimitReached) {
       setQueuedClaps((c) => c + 1)
+      cb?.()
     }
   }
 

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -36,8 +36,8 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
     imagePublicURL,
   } = pageContext
 
-  const { data: res, error } = useFetch<GetClapsResponse, any>(
-    `${URI}?slug=${location.pathname}`
+  const { data: res, error } = useFetch<QueryClapsResponse, any>(
+    `${URI}/query?slug=${location.pathname}`
   )
   const isLoading = !res && !error
 
@@ -206,22 +206,23 @@ export const pageQuery = graphql`
   }
 `
 
-interface GetClapsResponse {
-  Item: Item
-}
-
-interface Item {
-  PK: Key
-  SK: Key
-  claps: _Claps
-}
-
-interface _Claps {
-  N: string
-}
-
-interface Key {
-  S: string
+interface QueryClapsResponse {
+  /**
+   * The current slug
+   */
+  slug: string
+  /**
+   * The total number of of claps for a given slug
+   */
+  total: number
+  /**
+   * The number of claps that the current user has committed
+   */
+  viewerClapCount: number
+  /**
+   * The total number of unique voters
+   */
+  voterCount: number
 }
 
 const Svg = styled(animated.svg)`

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -123,8 +123,8 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
       <ClapsLayoutContainer>
         <Claps>
           {transitions.map(({ item, props, key }, i) => (
-            <Remover>
-              <PlusCounter key={key} style={props} widthPx={100}>
+            <Remover key={key}>
+              <PlusCounter style={props} widthPx={100}>
                 +1
               </PlusCounter>
             </Remover>
@@ -148,10 +148,8 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
       <ClapsFixedContainer>
         <Claps>
           {transitions.map(({ item, props, key }) => (
-            <Remover>
-              <PlusCounter key={key} style={props}>
-                +1
-              </PlusCounter>
+            <Remover key={key}>
+              <PlusCounter style={props}>+1</PlusCounter>
             </Remover>
           ))}
           {isLoading ? (

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -45,6 +45,8 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
     URI
   )
 
+  const clapsToDisplay: number = parseInt(res?.total ?? "0") + clapsCount
+
   const [items, setItems] = useState<{ id: string }[]>([])
   const transitions = useTransition(items, (item) => item.id, {
     from: () => {
@@ -134,7 +136,7 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
           ) : (
             <>
               <div style={{ display: "flex" }}>
-                <span>{parseInt(res?.Item?.claps.N ?? "0") + clapsCount}</span>
+                <span>{clapsToDisplay}</span>
                 <div onClick={handleClick}>
                   <ThumsUp />
                 </div>
@@ -157,7 +159,7 @@ export default function BlogPostTemplate({ data, pageContext, location }) {
           ) : (
             <>
               <div style={{ display: "flex", justifyContent: `center` }}>
-                <span>{parseInt(res?.Item?.claps.N ?? "0") + clapsCount}</span>
+                <span>{clapsToDisplay}</span>
                 <div onClick={handleClick}>
                   <ThumsUp />
                 </div>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -269,7 +269,19 @@ const ThumsUp = memo(() => {
 interface PlusCounterProps {
   widthPx?: number
 }
-const PlusCounter = styled(animated.div)<PlusCounterProps>`
+
+/**
+ * @see https://styled-components.com/releases#v5.1.0
+ *
+ * Fix ERROR:
+ * > Warning: React does not recognize the `widthPx` prop on a DOM element.
+ * > If you intentionally want it to appear in the DOM as a custom attribute,
+ * > spell it as lowercase `widthpx` instead. If you accidentally passed it
+ * > from a parent component, remove it from the DOM element.
+ */
+const PlusCounter = styled(animated.div).withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) => !["widthPx"].includes(prop),
+})<PlusCounterProps>`
   pointer-events: none;
 
   color: ${theme("mode", {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -227,9 +227,15 @@ interface QueryClapsResponse {
   voterCount: number
 }
 
-const Svg = styled(animated.svg)`
+interface SvgProps {
+  viewerHasClapped?: boolean
+}
+const Svg = styled(animated.svg).withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    !["viewerHasClapped"].includes(prop),
+})<SvgProps>`
   cursor: pointer;
-  transition: color 50ms ease-in-out, transform 100ms ease-in-out;
+  transition: color 100ms ease-in-out, transform 100ms ease-in-out;
   will-change: color;
   color: ${theme("mode", {
     light: Colors.BLACK_DARKER,
@@ -242,17 +248,22 @@ const Svg = styled(animated.svg)`
     })};
   }
   :active {
-    color: ${theme("mode", {
-      light: Colors.CYAN,
-      dark: Colors.PURPLE,
-    })};
     transform: scale(1.2);
   }
+  ${(p) =>
+    p.viewerHasClapped &&
+    css`
+      fill: ${theme("mode", {
+        light: Colors.CYAN,
+        dark: Colors.PURPLE,
+      })};
+    `}
 `
 
-const ThumsUp = memo(() => {
+const ThumsUp = memo(({ viewerHasClapped }: { viewerHasClapped?: boolean }) => {
   return (
     <Svg
+      viewerHasClapped={viewerHasClapped}
       viewBox="0 0 24 24"
       width="24"
       height="24"


### PR DESCRIPTION
Fix a lot of bugs
- react key warnings
- react unrecognized props errors (with `styled-components`)

```diff
/**
 * @see https://styled-components.com/releases#v5.1.0
 *
 * Fix ERROR:
 * > Warning: React does not recognize the `widthPx` prop on a DOM element.
 * > If you intentionally want it to appear in the DOM as a custom attribute,
 * > spell it as lowercase `widthpx` instead. If you accidentally passed it
 * > from a parent component, remove it from the DOM element.
 */
```

Consume new API Gateway response shape
- Refactored the Rust Lambda function (under the hood)
- see https://github.com/thiskevinwang/rust-lambda/pull/2