### PR TITLE
[v0.18.0] App page updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.18.0] - 2020-11-19
+
+### Notes
+
+To make the Facebook <> Cognito login _smooth_, I needed **2 lambda triggers**, and to **catch Cognito errors, client side** ( see `src/pages/redirect_uri.tsx` ).
+
+**Pre Sign Up**
+
+- If the request is from **Facebook**
+  - auto create **Native** user
+    - auto verify email = TRUE
+    - auto confirm user = TRUE
+  - link the pending **Facebook** user
+  - return the **Facebook** event to Cognito
+  - expect Cognito to return an error: `Already found an entry for username ___`
+  - 👍 catch the error client side, and attempt to login with **Facebook** again
+    - 👍 when the user authenticates with **Facebook**, tokens for the **Native** user will be returned
+    - ❌ and the **Native** user's "email verified" will be auto set to FALSE
+      - as a result, password reset codes won't be emailed. Fix below
+
+**Pre Token Generation**
+
+- If the request is from **Facebook**
+  - `adminUpdateUserAttributes`
+    - ```ts
+      params = {
+        // ...
+        UserAttributes: [
+          {
+            Name: "email_verified",
+            Value: "true",
+          },
+        ],
+      }
+      ```
+  - This re-enables password reset codes to be sent for the **Native** user
+
+### Added
+
+- `/app/` client-only route
+  - `/app/profile`
+  - `/app/
+  - Followed: https://www.gatsbyjs.com/docs/client-only-routes-and-user-authentication/
+- LoadingPage component
+
+### Changed
+
+- LoadingIndicator style
+- numerous type annotation fix and improvements
+- return extra fields from `useVerifyTokenSet`
+- Simplified link/`<a>` styles
+
+### Todos
+
+- Add GOOGLE federated login w/ Cognito
+- Use new FS Route API
+  - https://www.gatsbyjs.com/blog/fs-route-api/
+
 ## [v0.17.1] - 2020-11-15
 
 ### Added
@@ -114,6 +172,7 @@ New:
 
 ### Added
 
+[v0.18.0]: https://github.com/thiskevinwang/coffee-code-climb/compare/v0.17.1...v0.18.0
 [v0.17.1]: https://github.com/thiskevinwang/coffee-code-climb/compare/v0.17.0...v0.17.1
 [v0.17.0]: https://github.com/thiskevinwang/coffee-code-climb/compare/v0.16.1...v0.17.0
 [v0.16.1]: https://github.com/thiskevinwang/coffee-code-climb/compare/v0.16.0...v0.16.1

--- a/src/components/App/Default.tsx
+++ b/src/components/App/Default.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import type { RouteComponentProps } from "@reach/router"
+import { LoadingPage } from "components/LoadingPage"
 
 export const Default = ({ navigate }: RouteComponentProps) => {
   navigate?.("/app/profile")
-  return null
+  return <LoadingPage />
 }

--- a/src/components/App/Default.tsx
+++ b/src/components/App/Default.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+import type { RouteComponentProps } from "@reach/router"
+
+export const Default = ({ navigate }: RouteComponentProps) => {
+  navigate?.("/app/profile")
+  return null
+}

--- a/src/components/App/Profile.tsx
+++ b/src/components/App/Profile.tsx
@@ -8,7 +8,8 @@ export const Profile = (
   return (
     <>
       <h2>Profile</h2>
-      <pre>{JSON.stringify(props.data, null, 2)}!</pre>
+      <p>Email: {props.data?.email}</p>
+      <p>Providers: {props.data?.identities?.map((e) => e.providerName)}</p>
     </>
   )
 }

--- a/src/components/App/Profile.tsx
+++ b/src/components/App/Profile.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import type { RouteComponentProps } from "@reach/router"
+import type { IdTokenPayload } from "utils"
+
+export const Profile = (
+  props: RouteComponentProps<{ data: IdTokenPayload | null }>
+) => {
+  return (
+    <>
+      <h2>Profile</h2>
+      <pre>{JSON.stringify(props.data, null, 2)}!</pre>
+    </>
+  )
+}

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import type { RouteComponentProps } from "@reach/router"
+
+export const Settings = (props: RouteComponentProps) => {
+  return (
+    <>
+      <h2>Settings</h2>
+      <pre>{JSON.stringify(props.data, null, 2)}</pre>
+    </>
+  )
+}

--- a/src/components/App/Settings.tsx
+++ b/src/components/App/Settings.tsx
@@ -5,7 +5,7 @@ export const Settings = (props: RouteComponentProps) => {
   return (
     <>
       <h2>Settings</h2>
-      <pre>{JSON.stringify(props.data, null, 2)}</pre>
+      <p>Coming soon! 🚧</p>
     </>
   )
 }

--- a/src/components/App/index.ts
+++ b/src/components/App/index.ts
@@ -1,0 +1,3 @@
+export { Default } from "./Default"
+export { Profile } from "./Profile"
+export { Settings } from "./Settings"

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { ButtonHTMLAttributes } from "react"
 import styled from "styled-components"
 import { animated, useSpring, config } from "react-spring"
 import { useGesture } from "react-use-gesture"
@@ -16,14 +16,13 @@ const MOUSEOVER_STYLE = {
 const MOUSEDOWN_STYLE = {
   transform: `scale(0.98)`,
 }
+
 interface Props {
-  isDarkMode: boolean
-  textSm: boolean
-  widthRem?: number
-  style?: React.CSSProperties
+  /** @deprecated Please remove and clean up */
+  textSm?: boolean
 }
 
-const Renderer = styled(animated.button)`
+const Renderer = styled(animated.button)<Props>`
   background: var(--background);
   color: var(--text);
 
@@ -64,7 +63,9 @@ const Renderer = styled(animated.button)`
  * </Button>
  * ```
  */
-export const Button = (props: Props) => {
+export const Button: React.FC<
+  Props & ButtonHTMLAttributes<HTMLButtonElement>
+> = ({ textSm, ...props }) => {
   const [springProps, set] = useSpring(() => ({
     from: { ...FROM_STYLE },
     config: config.stiff,
@@ -81,7 +82,7 @@ export const Button = (props: Props) => {
   return (
     <Renderer
       {...props}
-      style={{ ...springProps, width: `${props.widthRem}rem`, ...props.style }}
+      style={{ ...springProps, ...props.style }}
       {...bind()}
     />
   )

--- a/src/components/ColorSchemeProvider/GlobalTypographyStyles.tsx
+++ b/src/components/ColorSchemeProvider/GlobalTypographyStyles.tsx
@@ -41,12 +41,17 @@ export const GlobalTypographyStyles = createGlobalStyle<Props>`
   }
   a {
     color: var(--text);
-    box-shadow: var(--purple-or-cyan) 0px -5px 0px inset;
+    text-shadow: var(--shadow);
+    transition: color 200ms ease-in-out;
+    :hover {
+      color: var(--purple-or-cyan);
+    }
+    /* box-shadow: var(--purple-or-cyan) 0px -5px 0px inset;
     transition: box-shadow 200ms ease-in-out;
 
     :hover {
       box-shadow: var(--purple-or-cyan) 0px -1.5rem 0px inset;
-    }
+    } */
   }
 
   /**

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -13,7 +13,10 @@ export default function Footer() {
   return (
     <footer style={footerStyle}>
       <p>
-        <a href={GIT}>Github</a>&nbsp;|&nbsp;
+        <a href={GIT} rel="noopener noreferrer" target="_blank">
+          Github
+        </a>
+        &nbsp;|&nbsp;
         <Link to="/privacy">Privacy Policy</Link>&nbsp;|&nbsp;
         <Link to="/terms">Terms of Service</Link>
         {process.env.NODE_ENV === "development" && (

--- a/src/components/Layout2Components/NavBar2.tsx
+++ b/src/components/Layout2Components/NavBar2.tsx
@@ -11,7 +11,6 @@ import { Button } from "components/Button"
 
 import { setPostsVersion, setCognito, RootState } from "_reduxState"
 import { useVerifyTokenSet } from "utils"
-import { useCognito } from "utils/Playground/useCognito"
 
 const flexRowAlignItemsCenter = css`
   display: flex;
@@ -84,6 +83,8 @@ const NavBar2 = () => {
       <BarItem>
         {isLoggedIn === true && (
           <>
+            <Link to={"/app"}>App</Link>
+            <span>&nbsp;|&nbsp;</span>
             <a
               href="/playground"
               onClick={async (event) => {
@@ -94,7 +95,6 @@ const NavBar2 = () => {
             >
               Logout
             </a>
-
             <span>&nbsp;|&nbsp;Hello, {decoded?.email}</span>
           </>
         )}

--- a/src/components/LoadingIndicator/index.tsx
+++ b/src/components/LoadingIndicator/index.tsx
@@ -1,46 +1,53 @@
-import React, { useReducer, useEffect } from "react"
+import React, { useReducer, useEffect, FC, CSSProperties } from "react"
+import styled, { BaseProps } from "styled-components"
+import theme from "styled-theming"
+
 // https://en.wiktionary.org/wiki/%E2%A0%BC
 const ICONS = ["⠇", "⠋", "⠙", "⠸", "⠴", "⠦"]
-const COLORS = ["red", "orange", "goldenyellow", "green", "blue", "purple"]
+const COLORS_LIGHT = [
+  "#ee0000",
+  "#f5a623",
+  "#50e3c2",
+  "#0070f3",
+  "#7928ca",
+  "#f81ce5",
+]
+const COLORS_DARK = [
+  "#ff1a1a",
+  "#f7b955",
+  "#79ffe1",
+  "#3291ff",
+  "#8a63d2",
+  "#ff0080",
+]
+
+interface Props {
+  style?: CSSProperties
+}
+
+const Spinner = styled.div<Props & { interval: number }>`
+  color: ${(p) =>
+    theme("mode", {
+      light: COLORS_LIGHT[p.interval],
+      dark: COLORS_DARK[p.interval],
+    })};
+  text-shadow: var(--shadow);
+`
 
 /**
  * # LoadingIndicator
  */
-export const LoadingIndicator = ({ style = {} }) => {
-  const [i, spin] = useReducer(s => (s + 1) % 6, 0)
+export const LoadingIndicator: FC<Props> = ({ style = {} }) => {
+  const [i, spin] = useReducer((s) => (s + 1) % 6, 0)
   useEffect(() => {
     const interval = setInterval(spin, 50)
     return () => {
       clearInterval(interval)
     }
   }, [])
-
-  const [showMessage, setShowMessageTrue] = useReducer(s => true, false)
-  useEffect(() => {
-    const timeout = setTimeout(setShowMessageTrue, 2000)
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [])
-
-  const reloadPage = e => {
-    window?.location.reload(true)
-  }
-
-  const linkProps = {
-    href: "#",
-    onClick: reloadPage,
-  }
-
   return (
-    <>
-      <div style={{ ...style, color: COLORS[i] }}>{ICONS[i]}</div>
-      {showMessage && (
-        <p>
-          Sorry, this is taking a while to load...{" "}
-          <a {...linkProps}>Reload the page</a>
-        </p>
-      )}
-    </>
+    <Spinner style={{ ...style }} interval={i}>
+      {ICONS[i]}
+    </Spinner>
   )
 }

--- a/src/components/LoadingPage/index.tsx
+++ b/src/components/LoadingPage/index.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import styled from "styled-components"
+
+import { LoadingIndicator } from "components/LoadingIndicator"
+
+const FullPage = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: var(--background);
+  height: 100vh;
+  width: 100%;
+`
+export const LoadingPage = () => {
+  return (
+    <FullPage>
+      <LoadingIndicator style={{ fontSize: 96 }} />
+    </FullPage>
+  )
+}

--- a/src/components/LoadingPage/index.tsx
+++ b/src/components/LoadingPage/index.tsx
@@ -2,19 +2,31 @@ import React from "react"
 import styled from "styled-components"
 
 import { LoadingIndicator } from "components/LoadingIndicator"
+import { useSelector } from "react-redux"
+import { useSpring, animated } from "react-spring"
+import { Colors } from "consts/Colors"
 
-const FullPage = styled.div`
+const FullPage = styled(animated.div)`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: var(--background);
   height: 100vh;
   width: 100%;
 `
+
+const useAnimatedBg = () => {
+  const isDarkMode = useSelector((state: any) => state.isDarkMode)
+  const { background } = useSpring({
+    background: isDarkMode ? Colors.BLACK_DARKER : Colors.SILVER_LIGHT,
+  })
+  return { style: { background } }
+}
+
 export const LoadingPage = () => {
+  const props = useAnimatedBg()
   return (
-    <FullPage>
+    <FullPage {...props}>
       <LoadingIndicator style={{ fontSize: 96 }} />
     </FullPage>
   )

--- a/src/components/MobileMenu/index.tsx
+++ b/src/components/MobileMenu/index.tsx
@@ -47,21 +47,21 @@ export function usePrevious(value: boolean) {
  */
 export const MobileMenu = ({ defaultOpen = false }) => {
   const { isDarkMode, layoutVersion, showMobileMenu } = useSelector(
-    state => state
+    (state) => state
   )
-  const postsVersion: 1 | 2 | 3 = useSelector(state => state.postsVersion)
+  const postsVersion: 1 | 2 | 3 = useSelector((state) => state.postsVersion)
   const dispatch = useDispatch()
 
   const dispatchSetIsDarkMode = useCallback(
-    value => e => dispatch(setIsDarkMode(value)),
+    (value) => (e) => dispatch(setIsDarkMode(value)),
     []
   )
   const dispatchSetLayoutVersion = useCallback(
-    value => e => dispatch(setLayoutVersion(value)),
+    (value) => (e) => dispatch(setLayoutVersion(value)),
     []
   )
   const dispatchSetPostsVersion = useCallback(
-    value => e => dispatch(setPostsVersion(value)),
+    (value) => (e) => dispatch(setPostsVersion(value)),
     []
   )
 
@@ -93,26 +93,17 @@ export const MobileMenu = ({ defaultOpen = false }) => {
       }}
     >
       <Renderer style={{ transform }} {...bind}>
-        <Button
-          sm
-          textSm
-          isDarkMode={isDarkMode}
-          onClick={dispatchSetIsDarkMode(!isDarkMode)}
-        >
+        <Button textSm onClick={dispatchSetIsDarkMode(!isDarkMode)}>
           <span>{`Dark Mode`}</span> <label>{isDarkMode ? "on" : "off"}</label>
         </Button>
         <Button
-          sm
           textSm
-          isDarkMode={isDarkMode}
           onClick={dispatchSetLayoutVersion((layoutVersion % 2) + 1)}
         >
           <span>{`Layout Version`}</span> <label>V{layoutVersion}</label>
         </Button>
         <Button
-          sm
           textSm
-          isDarkMode={isDarkMode}
           onClick={dispatchSetPostsVersion((postsVersion % 2) + 1)}
         >
           <span>{`Posts Version`}</span> <label>V{postsVersion}</label>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -80,30 +80,18 @@ const NavBar = () => {
 
   return (
     <Bar isDarkMode={isDarkMode}>
-      <Button
-        sm
-        textSm
-        isDarkMode={isDarkMode}
-        onClick={dispatchSetIsDarkMode(!isDarkMode)}
-      >
+      <Button textSm onClick={dispatchSetIsDarkMode(!isDarkMode)}>
         <span>{`Dark Mode`}</span>
         <label>{isDarkMode ? "on" : "off"}</label>
       </Button>
       <Button
-        sm
         textSm
-        isDarkMode={isDarkMode}
         onClick={dispatchSetLayoutVersion((layoutVersion % 2) + 1)}
       >
         <span>{`Layout Version`}</span>
         <label>V{layoutVersion}</label>
       </Button>
-      <Button
-        sm
-        textSm
-        isDarkMode={isDarkMode}
-        onClick={dispatchSetPostsVersion((postsVersion % 2) + 1)}
-      >
+      <Button textSm onClick={dispatchSetPostsVersion((postsVersion % 2) + 1)}>
         <span>{`Posts Version`}</span>
         <label>V{postsVersion}</label>
       </Button>

--- a/src/components/layout2.tsx
+++ b/src/components/layout2.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react"
 import { useSelector } from "react-redux"
 import { useSpring, animated, OpaqueInterpolation } from "react-spring"
 import { compose } from "redux"
-import { Link } from "gatsby"
+import { Link, PageProps } from "gatsby"
 import styled from "styled-components"
 
 import { NavBar2 } from "components/Layout2Components/NavBar2"
@@ -24,7 +24,11 @@ const ThemedBackground = styled(animated.div)`
   z-index: -9000;
 `
 
-function Layout({ location, title, children }) {
+interface Props {
+  location: PageProps["location"]
+  title: string
+}
+const Layout: React.FC<Props> = ({ location, title, children }) => {
   const rootPath: string = `${__PATH_PREFIX__}/`
   const topLink =
     location.pathname === rootPath ? <h1>{title}</h1> : <h3>← 🏠</h3>
@@ -42,7 +46,7 @@ function Layout({ location, title, children }) {
       <ThemedBackground style={{ background }} />
       <NavBar2 />
 
-      <animated.div
+      <div
         style={{
           marginLeft: `auto`,
           marginRight: `auto`,
@@ -64,7 +68,7 @@ function Layout({ location, title, children }) {
         </Link>
         <main>{children}</main>
         <Footer />
-      </animated.div>
+      </div>
       <BlobHolder>
         <Blob y={scrollYPercent} />
       </BlobHolder>

--- a/src/components/layoutManager.tsx
+++ b/src/components/layoutManager.tsx
@@ -1,26 +1,22 @@
-import React, {
-  useState,
-  useReducer,
-  useEffect,
-  useRef,
-  useCallback,
-} from "react"
-import { useSelector, useDispatch } from "react-redux"
-import styled from "styled-components"
-import { useSpring, useChain, animated, AnimatedValue } from "react-spring"
+import React, { useState, useReducer, useEffect, useCallback } from "react"
+import type { PageProps } from "gatsby"
+import { useSelector } from "react-redux"
+import { useSpring } from "react-spring"
 
 import Layout from "./layout"
 import Layout2 from "./layout2"
-import { setLayoutVersion, RootState } from "_reduxState"
-import { rhythm } from "utils/typography"
+import { RootState } from "_reduxState"
 import { FunButtonsModal } from "components/FunButtonsModal"
 
 import * as Colors from "consts/Colors"
 
+interface Props {
+  location: PageProps["location"]
+}
 /**
  * ⚠️ Don't destructure props!
  */
-const LayoutManager = (props) => {
+const LayoutManager = (props: Props) => {
   const { pathname } = props.location
   const [showModal, setShowModal] = useState(false)
   const [shouldExit, setShouldExit] = useState(false)
@@ -31,7 +27,6 @@ const LayoutManager = (props) => {
 
   const isDarkMode = useSelector((state: RootState) => state.isDarkMode)
   const layoutVersion = useSelector((state: RootState) => state.layoutVersion)
-  const dispatch = useDispatch()
 
   const neverModalShowAgain =
     typeof window !== "undefined" &&

--- a/src/components/layoutManager.tsx
+++ b/src/components/layoutManager.tsx
@@ -16,7 +16,7 @@ interface Props {
 /**
  * ⚠️ Don't destructure props!
  */
-const LayoutManager = (props: Props) => {
+const LayoutManager: React.FC<Props> = (props) => {
   const { pathname } = props.location
   const [showModal, setShowModal] = useState(false)
   const [shouldExit, setShouldExit] = useState(false)

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { navigate, PageProps } from "gatsby"
+import { navigate, PageProps, Link } from "gatsby"
 import { Router } from "@reach/router"
 import { LayoutManager } from "components/layoutManager"
+import { LoadingPage } from "components/LoadingPage"
 
 import { Profile, Settings, Default } from "components/App"
 
@@ -11,14 +12,10 @@ import { useVerifyTokenSet } from "utils"
  * Anything at `/app/*` requires the user to be authenticated
  */
 const App = ({ location }: PageProps) => {
-  const { isLoggedIn, decoded } = useVerifyTokenSet()
+  const { isLoggedIn, decoded, decodedAcc } = useVerifyTokenSet()
 
   if (isLoggedIn === null) {
-    return (
-      <LayoutManager location={location}>
-        <h1>...</h1>
-      </LayoutManager>
-    )
+    return <LoadingPage />
   }
   if (isLoggedIn === false) {
     navigate("/auth/login")
@@ -27,9 +24,13 @@ const App = ({ location }: PageProps) => {
   return (
     <LayoutManager location={location}>
       <h1>App</h1>
-
-      <pre>{JSON.stringify(location.state, null, 2)}</pre>
-
+      <Link to="/app/profile">Profile</Link>&nbsp;
+      <Link to="/app/settings">Settings</Link>
+      {/* <h4>Location State</h4>
+      <pre>{JSON.stringify(location.state, null, 2)}</pre> */}
+      <h2>Username</h2>
+      <p>{decodedAcc?.username}</p>
+      {/* <pre>{JSON.stringify(decodedAcc, null, 2)}</pre> */}
       <Router basepath="/app">
         <Profile path="/profile" data={decoded} />
         <Settings path="/settings" />
@@ -38,4 +39,5 @@ const App = ({ location }: PageProps) => {
     </LayoutManager>
   )
 }
+
 export default App

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,10 +1,16 @@
 import React from "react"
-import { navigate } from "gatsby"
+import { navigate, PageProps } from "gatsby"
 import { Router } from "@reach/router"
 import { LayoutManager } from "components/layoutManager"
+
+import { Profile, Settings, Default } from "components/App"
+
 import { useVerifyTokenSet } from "utils"
 
-const App = ({ location }: { location: Location }) => {
+/**
+ * Anything at `/app/*` requires the user to be authenticated
+ */
+const App = ({ location }: PageProps) => {
   const { isLoggedIn, decoded } = useVerifyTokenSet()
 
   if (isLoggedIn === null) {
@@ -21,8 +27,14 @@ const App = ({ location }: { location: Location }) => {
   return (
     <LayoutManager location={location}>
       <h1>App</h1>
-      <pre>{JSON.stringify(decoded, null, 2)}</pre>
-      <Router></Router>
+
+      <pre>{JSON.stringify(location.state, null, 2)}</pre>
+
+      <Router basepath="/app">
+        <Profile path="/profile" data={decoded} />
+        <Settings path="/settings" />
+        <Default path="/*" />
+      </Router>
     </LayoutManager>
   )
 }

--- a/src/pages/attack-animation-simulator.tsx
+++ b/src/pages/attack-animation-simulator.tsx
@@ -352,11 +352,11 @@ function AttackAnimationSimulator(props) {
       <SEO title="Attack Animation Simulator" />
       <h1>Attack Animation Simulator</h1>
       <div className="container" style={{ height: `100vh` }}>
-        <Button isDarkMode={isDarkMode} onClick={attack}>
+        <Button onClick={attack}>
           <label>(Press A)</label>
           <span>Attack</span>
         </Button>
-        <Button isDarkMode={isDarkMode} onClick={reset}>
+        <Button onClick={reset}>
           <label>(Press R)</label>
           <span>Reset</span>
         </Button>

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -14,9 +14,11 @@ import { FacebookIcon } from "icons"
 import { useVerifyTokenSet } from "utils"
 import { useCognito } from "utils/Playground/useCognito"
 
-const GATSBY_FACEBOOK_LOGIN_LINK = process.env.GATSBY_FACEBOOK_LOGIN_LINK
+const GATSBY_FACEBOOK_LOGIN_LINK = process.env
+  .GATSBY_FACEBOOK_LOGIN_LINK as string
 
-const GATSBY_COGNITO_REDIRECT_URI = process.env.GATSBY_COGNITO_REDIRECT_URI
+const GATSBY_COGNITO_REDIRECT_URI = process.env
+  .GATSBY_COGNITO_REDIRECT_URI as string
 
 const Error = styled.p`
   border: 3px solid #ff7979;

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Formik, FormikProps, FormikErrors } from "formik"
-import { navigate } from "gatsby"
+import { navigate, PageProps } from "gatsby"
 import styled from "styled-components"
 import _ from "lodash"
 import { graphql } from "gatsby"
@@ -32,7 +32,7 @@ type Values = {
   email: string
   password: string
 }
-const AuthLogin = ({ location }: { location: Location }) => {
+const AuthLogin = ({ location }: PageProps) => {
   const { initiateAuth, errorMessage } = useCognito()
   const { isLoggedIn } = useVerifyTokenSet()
   if (isLoggedIn === true) {
@@ -112,8 +112,10 @@ const AuthLogin = ({ location }: { location: Location }) => {
           window.location.href = GATSBY_COGNITO_REDIRECT_URI
         }}
       >
-        Launch Hosted UI
+        Sign Up
       </Button>
+      <span>&nbsp;— OR —&nbsp;</span>
+
       <br />
       <Button
         style={{

--- a/src/pages/redirect_uri.tsx
+++ b/src/pages/redirect_uri.tsx
@@ -48,6 +48,13 @@ const RedirectUri = ({ location }: { location: Location }) => {
   console.log("error:", cognito_error)
   console.log("error_description;", error_description)
 
+  /**
+   * @warn Login with facebook button link, causes the native Cognito user's
+   * `email_verified` to BECOME `false`, even if it was originally true...
+   *
+   * for "Already found an entry for username..." issue
+   * @see https://stackoverflow.com/questions/47815161/cognito-auth-flow-fails-with-already-found-an-entry-for-username-facebook-10155
+   */
   if (
     error_description?.includes?.("LINK_SUCCESS") ||
     error_description?.includes?.("Already found an entry for username")
@@ -65,7 +72,6 @@ const RedirectUri = ({ location }: { location: Location }) => {
       })
     },
     onError: (err) => {
-      const result = {}
       dispatch(setCognito(null, err))
       navigate("/auth/login", {
         replace: true,
@@ -82,13 +88,13 @@ const RedirectUri = ({ location }: { location: Location }) => {
    */
   useEffect(() => {
     if (!code) {
-      // navigate("/auth/login", {
-      //   replace: true,
-      //   state: {
-      //     data: null,
-      //     error: { code, error_description, cognito_error },
-      //   },
-      // })
+      navigate("/auth/login", {
+        replace: true,
+        state: {
+          data: null,
+          error: { code, error_description, cognito_error },
+        },
+      })
     } else {
       const variables: GetTokenVars = {
         code: code as string,

--- a/src/pages/redirect_uri.tsx
+++ b/src/pages/redirect_uri.tsx
@@ -91,9 +91,9 @@ const RedirectUri = ({ location }: { location: Location }) => {
   return (
     <LayoutManager location={location}>
       <SEO title="Redirecting..." />
-      <h3>{code}</h3>
+      {/* <h3>{code}</h3>
       <h3>{cognito_error}</h3>
-      <h4>{error_description}</h4>
+      <h4>{error_description}</h4> */}
 
       {!data && !error && (
         <>
@@ -102,21 +102,21 @@ const RedirectUri = ({ location }: { location: Location }) => {
         </>
       )}
 
-      {error && (
+      {/* {error && (
         <>
           <h2>ERROR</h2>
           <pre>{JSON.stringify(error, null, 2)}</pre>
         </>
-      )}
+      )} */}
 
-      {data && (
+      {/* {data && (
         <>
           <h2>Data</h2>
           <pre>{data.getToken.AccessToken}</pre>
           <pre>{data.getToken.IdToken}</pre>
           <pre>{data.getToken.RefreshToken}</pre>
         </>
-      )}
+      )} */}
     </LayoutManager>
   )
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { getContrast } from "./getContrast"
 export { isBrowser } from "./isBrowser"
-export { useVerifyTokenSet } from "./useVerifyTokenSet"
+export { useVerifyTokenSet, IdTokenPayload } from "./useVerifyTokenSet"

--- a/src/utils/useVerifyTokenSet.ts
+++ b/src/utils/useVerifyTokenSet.ts
@@ -69,7 +69,7 @@ interface FederatedIdentity {
   providerType: string
   userId: string // number
 }
-interface IdTokenPayload {
+export interface IdTokenPayload {
   at_hash: string
   aud: string
   auth_time: number

--- a/src/utils/useVerifyTokenSet.ts
+++ b/src/utils/useVerifyTokenSet.ts
@@ -33,7 +33,7 @@ const getKeyAsync = async (header?: JwtHeader) => {
   return pubKey
 }
 
-interface AccessTokenPayload {
+export interface AccessTokenPayload {
   /**
    * alias for username
    * @example '65a3f854-169b-48ab-b928-d5ddf747473c'
@@ -95,6 +95,7 @@ export const useVerifyTokenSet = () => {
 
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null)
   const [decoded, setDecoded] = useState<IdTokenPayload | null>(null)
+  const [decodedAcc, setDecodedAcc] = useState<AccessTokenPayload | null>(null)
 
   useEffect(() => {
     const verifyAsync = async () => {
@@ -111,6 +112,7 @@ export const useVerifyTokenSet = () => {
       let idTokenPayload: IdTokenPayload
 
       const decodedIdToken = jwt.decode(idToken, { complete: true })
+
       idTokenPayload = decodedIdToken?.payload
       email = idTokenPayload?.email
       const exp = idTokenPayload.exp
@@ -130,6 +132,7 @@ export const useVerifyTokenSet = () => {
         const decodedAccessToken = jwt.decode(accessToken, {
           complete: true,
         })
+        setDecodedAcc(decodedAccessToken.payload)
         const tokenHeader: JwtHeader = decodedAccessToken?.header
         const pubKey = await getKeyAsync(tokenHeader)
         jwt.verify(accessToken, pubKey)
@@ -168,9 +171,9 @@ export const useVerifyTokenSet = () => {
             }
 
             let data = await cognito.initiateAuth(params).promise()
+            // copy over previous refresh token
             data.AuthenticationResult.RefreshToken = refreshToken
 
-            // window.localStorage.setItem("cognito", JSON.stringify(data))
             console.warn("Refresh succeeded; Updating redux")
             dispatch(setCognito(data, null))
 
@@ -184,6 +187,7 @@ export const useVerifyTokenSet = () => {
             jwt.verify(accessToken, pubKey) as AccessTokenPayload
             console.warn("verify refreshed token succeeded")
 
+            setDecodedAcc(decodedAccessToken.payload)
             setDecoded(idTokenPayload)
             setIsLoggedIn(true)
             return
@@ -204,5 +208,5 @@ export const useVerifyTokenSet = () => {
     verifyAsync()
   }, [accessToken, idToken, refreshToken])
 
-  return { isLoggedIn, decoded }
+  return { isLoggedIn, decoded, decodedAcc }
 }


### PR DESCRIPTION
## [v0.18.0] - 2020-11-19

### Notes

To make the Facebook <> Cognito login _smooth_, I needed **2 lambda triggers**, and to **catch Cognito errors, client side** ( see `src/pages/redirect_uri.tsx` ).

**Pre Sign Up**

- If the request is from **Facebook**
  - auto create **Native** user
    - auto verify email = TRUE
    - auto confirm user = TRUE
  - link the pending **Facebook** user
  - return the **Facebook** event to Cognito
  - expect Cognito to return an error: `Already found an entry for username ___`
  - 👍 catch the error client side, and attempt to login with **Facebook** again
    - 👍 when the user authenticates with **Facebook**, tokens for the **Native** user will be returned
    - ❌ and the **Native** user's "email verified" will be auto set to FALSE
      - as a result, password reset codes won't be emailed. Fix below

**Pre Token Generation**

- If the request is from **Facebook**
  - `adminUpdateUserAttributes`
    - ```ts
      params = {
        // ...
        UserAttributes: [
          {
            Name: "email_verified",
            Value: "true",
          },
        ],
      }
      ```
  - This re-enables password reset codes to be sent for the **Native** user

### Added

- `/app/` client-only route
  - `/app/profile`
  - `/app/
  - Followed: https://www.gatsbyjs.com/docs/client-only-routes-and-user-authentication/
- LoadingPage component

### Changed

- LoadingIndicator style
- numerous type annotation fix and improvements
- return extra fields from `useVerifyTokenSet`
- Simplified link/`<a>` styles

### Todos

- Add GOOGLE federated login w/ Cognito
- Use new FS Route API
  - https://www.gatsbyjs.com/blog/fs-route-api/